### PR TITLE
Add missing posts_categories table renaming

### DIFF
--- a/updates/v2.0.0/rename_tables.php
+++ b/updates/v2.0.0/rename_tables.php
@@ -7,7 +7,8 @@ class RenameTables extends Migration
 {
     const TABLES = [
         'categories',
-        'posts'
+        'posts',
+        'posts_categories'
     ];
 
     public function up()


### PR DESCRIPTION
The pivot table was missing, causing the blog plugin to crash when we add the posts list component.