### PR TITLE
Fix MariaDB's index renaming

### DIFF
--- a/updates/v2.0.1/rename_indexes.php
+++ b/updates/v2.0.1/rename_indexes.php
@@ -37,12 +37,12 @@ class RenameIndexes extends Migration
         $sm = Schema::getConnection()->getDoctrineSchemaManager();
 
         foreach ($sm->listTableIndexes($table) as $index) {
-            $old = $index->getName();
-            $new = str_replace($from, $to, $old);
-
             if ($index->isPrimary()) {
                 continue;
             }
+            
+            $old = $index->getName();
+            $new = str_replace($from, $to, $old);
 
             $columns = $index->getColumns();
             if ($index->isUnique()) {


### PR DESCRIPTION
MariaDB does not support renaming index on the latest LTS, we need to drop/recreate them.