### PR TITLE
Add unique rules to post.slug and category.slug

### DIFF
--- a/updates/v2.0.1/rename_indexes.php
+++ b/updates/v2.0.1/rename_indexes.php
@@ -37,12 +37,12 @@ class RenameIndexes extends Migration
         $sm = Schema::getConnection()->getDoctrineSchemaManager();
 
         foreach ($sm->listTableIndexes($table) as $index) {
-            $old = $index->getName();
-            $new = str_replace($from, $to, $old);
-
             if ($index->isPrimary()) {
                 continue;
             }
+            
+            $old = $index->getName();
+            $new = str_replace($from, $to, $old);
 
             $columns = $index->getColumns();
             if ($index->isUnique()) {

--- a/updates/v2.0.2/add_unique_rules.php
+++ b/updates/v2.0.2/add_unique_rules.php
@@ -1,0 +1,47 @@
+<?php namespace Winter\Forum\Updates;
+
+use Schema;
+use Winter\Storm\Database\Updates\Migration;
+
+class AddUniqueRules extends Migration
+{
+    const UNIQUE_FIELDS = [
+        'posts' => ['slug'],
+        'categories' => ['slug']
+    ];
+
+    public function up()
+    {
+        foreach (array_keys(self::UNIQUE_FIELDS) as $table) {
+            $this->switchIndexes($table, 'Index', 'Unique');
+        }
+
+        Schema::table('winter_blog_categories', function($table) {
+           $table->unique('code');
+        });
+    }
+
+    public function down()
+    {
+        foreach (array_keys(self::UNIQUE_FIELDS) as $table) {
+            $this->switchIndexes($table, 'Unique', 'Index');
+        }
+    }
+
+    public function switchIndexes($tableName, $fromType, $toType) {
+        foreach (self::UNIQUE_FIELDS[$tableName] as $field) {
+            try {
+                $dropFunction = 'drop'.$fromType;
+                $createFunction = strtolower($toType);
+
+                Schema::table('winter_blog_'. $tableName, function($table) use ($field, $dropFunction, $createFunction)
+                {
+                    $table->$dropFunction([$field]);
+                    $table->$createFunction($field);
+                });
+            } catch (\Exception $exception) {
+                echo "Could not convert ${field} on the ${tableName} from ${fromType} to ${toType}" . PHP_EOL;
+            }
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -67,3 +67,6 @@
     - Add migrations for translate plugin attributes and indexes tables
     - v2.0.1/rename_indexes.php
     - v2.0.1/fix_translate_records.php
+"2.0.2":
+    - Add unique rules
+    - v2.0.2/add_unique_rules.php


### PR DESCRIPTION
According to the models, these columns should be unique.

Luke asked to make this migration "not breakable" so I wrapped the modification into a try catch.

If an exception is thrown during the process, it only echos a warning into the console.

