### PR TITLE
Set url of the current post model

### DIFF
--- a/components/Post.php
+++ b/components/Post.php
@@ -103,12 +103,18 @@ class Post extends ComponentBase
         $post = $query->first();
 
         /*
-         * Add a "url" helper attribute for linking to each category
+         * Add a "url" helper attribute for linking to each category and canonical url of the post
          */
-        if ($post && $post->exists && $post->categories->count()) {
-            $post->categories->each(function($category) {
-                $category->setUrl($this->categoryPage, $this->controller);
-            });
+        if ($post && $post->exists) {
+            $postPage = $this->getPage()->getBaseFileName();
+
+            $post->setUrl($postPage, $this->controller, []);
+
+            if ($post->categories->count()) {
+                $post->categories->each(function($category) {
+                    $category->setUrl($this->categoryPage, $this->controller);
+                });
+            }
         }
 
         return $post;

--- a/components/Post.php
+++ b/components/Post.php
@@ -108,7 +108,7 @@ class Post extends ComponentBase
         if ($post && $post->exists) {
             $postPage = $this->getPage()->getBaseFileName();
 
-            $post->setUrl($postPage, $this->controller, []);
+            $post->setUrl($postPage, $this->controller);
 
             if ($post->categories->count()) {
                 $post->categories->each(function($category) {


### PR DESCRIPTION
As discussed on Discord, because a post can have many URLs: one for each category it's related to, this would be handy to set the canonical URL of the page.