### PR TITLE
Added fixes to improve seo support for posts root page

### DIFF
--- a/components/Posts.php
+++ b/components/Posts.php
@@ -170,7 +170,8 @@ class Posts extends ComponentBase
 
             // Page number is not numeric or less than 1, then 404 as this is not a real page
             if (!is_numeric($currentPage) || $currentPage < 1) {
-                abort(404, 'Invalid page number.');
+                $this->setStatusCode(404);
+                return $this->controller->run('404');
             }
 
             // If the current page is bigger than the last page of pagination, then force the user back to the last page

--- a/components/Posts.php
+++ b/components/Posts.php
@@ -163,12 +163,19 @@ class Posts extends ComponentBase
         if ($pageNumberParam = $this->paramName('pageNumber')) {
             $currentPage = $this->property('pageNumber');
 
-            if ($currentPage > ($lastPage = $this->posts->lastPage()) && $currentPage > 1) {
-                return Redirect::to($this->currentPageUrl([$pageNumberParam => $lastPage]));
+            // If the page number has not been set, then default to page 1
+            if (!$currentPage) {
+                $this->setProperty('pageNumber', $currentPage = 1);
             }
 
-            if (!is_null($currentPage) && $currentPage < 1) {
-                return Redirect::to($this->currentPageUrl([$pageNumberParam => 1]));
+            // Page number is not numeric or less than 1, then 404 as this is not a real page
+            if (!is_numeric($currentPage) || $currentPage < 1) {
+                abort(404, 'Invalid page number.');
+            }
+
+            // If the current page is bigger than the last page of pagination, then force the user back to the last page
+            if ($currentPage > ($lastPage = $this->posts->lastPage()) && $currentPage > 1) {
+                return Redirect::to($this->currentPageUrl([$pageNumberParam => $lastPage]));
             }
         }
     }


### PR DESCRIPTION
This PR reverts the change added in https://github.com/wintercms/wn-blog-plugin/commit/ed072ea2502bf0d730951e8cfb8b80dbe73fc67c and replaces the logic with an internal pageNumber set and no redirect.

This is because:
- `/blog/category/test` used to be the root page for the test category. however after this change that page is no longer accessible and `/blog/category/test/1` is now the default. All the links that point to `/blog/category/test` are now seeing a 302 which creates a lot of "internal redirects" which search engines don't like (if you are linking to the category pages anywhere on your site).
- Also if the old root page `/blog/category/test` had good seo value, it is now lost as that page 302s to `/blog/category/test/1` and the original is no longer accessible.
- After this PR, `pageNumber` can never be unset or false, cannot be a negative number and cannot be non-numeric

