### PR TITLE
Add post author to default markup as an example

### DIFF
--- a/components/post/default.htm
+++ b/components/post/default.htm
@@ -30,3 +30,9 @@
         }) }}
     {% endif %}
 </p>
+
+{% if post.user %}
+<p class="info">
+  {{ 'winter.blog::lang.post.published_by' | trans }}: {{ post.user.first_name ~ ' ' ~ post.user.last_name }} 
+</p>
+{% endif %}


### PR DESCRIPTION
Displaying the Post author was a difficulty mentioned in Laraveldaily review.