### PR TITLE
Re-enable footnotes, tables and attributes in Markdown for Blog posts

### DIFF
--- a/models/Post.php
+++ b/models/Post.php
@@ -187,7 +187,10 @@ class Post extends Model
         if ($useRichEditor) {
             $result = trim($input);
         } else {
-            $result = Markdown::parse(trim($input));
+            $result = Markdown::enableFootnotes()
+                ->enableAttributes()
+                ->enableTables()
+                ->parse(trim($input));
         }
 
         // Check to see if the HTML should be cleaned from potential XSS


### PR DESCRIPTION
These features are not automatically enabled in our Markdown parser since the switch to the Commonmark library.

This PR explicitly re-enables them in order to maintain parity with the Parsedown Extra library that we used to use for Blog posts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Markdown parsing for posts created with the standard editor to properly support footnotes, attributes, and tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->