### PR TITLE
fix(PostImport): require `slug` to prevent import errors

### DIFF
--- a/models/PostImport.php
+++ b/models/PostImport.php
@@ -20,6 +20,7 @@ class PostImport extends ImportModel
     public $rules = [
         'title'   => 'required',
         'content' => 'required',
+        'slug'    => 'required',
     ];
 
     protected $authorEmailCache = [];


### PR DESCRIPTION
The `slug` attribute is now required in the `PostImport` model validation rules to ensure consistency with the `Post` model, which has had `slug` as required since Timeless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated post import validation to require a slug field in addition to title and content when importing posts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->