### PR TITLE
chore(composer): update PHP requirement to >=8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "source": "https://github.com/wintercms/wn-blog-plugin"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=8.1",
         "winter/wn-backend-module": "^1.2.8|dev-develop",
         "composer/installers": "~1.0"
     },


### PR DESCRIPTION
Align PHP version constraint with wn-backend-module dependency, which requires PHP >=8.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP version requirement to 8.1, raising the baseline from the previous 7.0 requirement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->