### PR TITLE
feat: Add admin dashboard widget for blog posts

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -163,6 +163,20 @@ class Plugin extends PluginBase
     }
 
     /**
+     * Register dashboard report widgets
+     */
+    public function registerReportWidgets()
+    {
+        return [
+            'Winter\Blog\ReportWidgets\Posts' => [
+                'label' => 'winter.blog::lang.widgets.posts.title',
+                'context' => 'dashboard',
+                'permissions' => [],
+            ],
+        ];
+    }
+
+    /**
      * Boot method, called when the plugin is first booted.
      */
     public function boot(): void

--- a/Plugin.php
+++ b/Plugin.php
@@ -171,7 +171,7 @@ class Plugin extends PluginBase
             'Winter\Blog\ReportWidgets\Posts' => [
                 'label' => 'winter.blog::lang.widgets.posts.title',
                 'context' => 'dashboard',
-                'permissions' => [],
+                'permissions' => ['winter.blog.access_posts'],
             ],
         ];
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -168,7 +168,7 @@ class Plugin extends PluginBase
     public function registerReportWidgets()
     {
         return [
-            'Winter\Blog\ReportWidgets\Posts' => [
+            \Winter\Blog\ReportWidgets\Posts::class => [
                 'label' => 'winter.blog::lang.widgets.posts.title',
                 'context' => 'dashboard',
                 'permissions' => ['winter.blog.access_posts'],

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -137,6 +137,7 @@ return [
             'upcoming' => 'Nächste Artikel',
             'no_upcoming_message' => 'Es gibt keine kommenden Artikel.',
             'latest' => 'Neuester Artikel',
+            'no_latest_message' => 'Kein veröffentlichter Artikel.',
         ],
     ],
 ];

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -129,4 +129,14 @@ return [
         'group_links' => 'Links',
         'group_exceptions' => 'Ausnahmen',
     ],
+    'widgets' => [
+        'posts' => [
+            'title' => 'Blogartikel',
+            'drafts' => 'Entwürfe',
+            'no_drafts_message' => 'Keine Entwürfe vorhanden.',
+            'upcoming' => 'Nächste Artikel',
+            'no_upcoming_message' => 'Es gibt keine kommenden Artikel.',
+            'latest' => 'Neuester Artikel',
+        ],
+    ],
 ];

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -172,4 +172,14 @@ return [
         'default_author_comment' => 'The import will try to use an existing author if you match the Author Email column, otherwise the author specified above is used.',
         'default_author_placeholder' => '-- select author --',
     ],
+    'widgets' => [
+        'posts' => [
+            'title' => 'Blog Posts',
+            'drafts' => 'Drafts',
+            'no_drafts_message' => 'There are no draft posts',
+            'upcoming' => 'Upcoming',
+            'no_upcoming_message' => 'There are no upcoming posts.',
+            'latest' => 'Latest Post',
+        ],
+    ],
 ];

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -180,6 +180,7 @@ return [
             'upcoming' => 'Upcoming',
             'no_upcoming_message' => 'There are no upcoming posts.',
             'latest' => 'Latest Post',
+            'no_latest_message' => 'No published posts',
         ],
     ],
 ];

--- a/reportwidgets/Posts.php
+++ b/reportwidgets/Posts.php
@@ -40,6 +40,6 @@ class Posts extends ReportWidgetBase
         ->whereNotNull('published_at')
         ->where('published_at', '>', Carbon::now())
         ->orderBy('published_at', 'asc')
-        ->take(5)->get();
+        ->limit(5)->get();
     }
 }

--- a/reportwidgets/Posts.php
+++ b/reportwidgets/Posts.php
@@ -34,12 +34,17 @@ class Posts extends ReportWidgetBase
 
     protected function loadData()
     {
-      $this->vars['latest'] = Post::isPublished()->first();
-      $this->vars['drafts'] = Post::where('published', false)->with('user')->orderBy('updated_at', 'desc')->limit(5)->get();
-      $this->vars['upcoming'] = Post::where('published', true)
-        ->whereNotNull('published_at')
-        ->where('published_at', '>', Carbon::now())
-        ->orderBy('published_at', 'asc')
-        ->limit(5)->get();
+        $this->vars['latest'] = Post::isPublished()->first();
+        $this->vars['drafts'] = Post::where('published', false)
+            ->with('user')
+            ->orderBy('updated_at', 'desc')
+            ->limit(5)
+            ->get();
+        $this->vars['upcoming'] = Post::where('published', true)
+            ->whereNotNull('published_at')
+            ->where('published_at', '>', Carbon::now())
+            ->orderBy('published_at', 'asc')
+            ->limit(5)
+            ->get();
     }
 }

--- a/reportwidgets/Posts.php
+++ b/reportwidgets/Posts.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Winter\Blog\ReportWidgets;
+
+use Backend\Classes\ReportWidgetBase;
+use Winter\Blog\Models\Post;
+use Carbon\Carbon;
+
+class Posts extends ReportWidgetBase
+{
+    public function render()
+    {
+        $this->loadData();
+        return $this->makePartial('widget');
+    }
+
+    protected function loadAssets()
+    {
+        $this->addCss('css/posts.css');
+    }
+
+    public function defineProperties()
+    {
+        return [
+            'title' => [
+                'title'             => 'backend::lang.dashboard.widget_title_label',
+                'default'           => 'winter.blog::lang.widgets.posts.title',
+                'type'              => 'string',
+                'validationPattern' => '^.+$',
+                'validationMessage' => 'backend::lang.dashboard.widget_title_error',
+            ]
+        ];
+    }
+
+    protected function loadData()
+    {
+      $this->vars['latest'] = Post::isPublished()->first();
+      $this->vars['drafts'] = Post::where('published', false)->take(5)->get();
+      $this->vars['upcoming'] = Post::where('published', true)
+        ->whereNotNull('published_at')
+        ->where('published_at', '>', Carbon::now())
+        ->orderBy('published_at', 'asc')
+        ->take(5)->get();
+    }
+}

--- a/reportwidgets/Posts.php
+++ b/reportwidgets/Posts.php
@@ -35,7 +35,7 @@ class Posts extends ReportWidgetBase
     protected function loadData()
     {
       $this->vars['latest'] = Post::isPublished()->first();
-      $this->vars['drafts'] = Post::where('published', false)->take(5)->get();
+      $this->vars['drafts'] = Post::where('published', false)->with('user')->orderBy('updated_at', 'desc')->limit(5)->get();
       $this->vars['upcoming'] = Post::where('published', true)
         ->whereNotNull('published_at')
         ->where('published_at', '>', Carbon::now())

--- a/reportwidgets/posts/assets/css/posts.css
+++ b/reportwidgets/posts/assets/css/posts.css
@@ -1,0 +1,7 @@
+#blog-posts .control-status-list {
+  margin: 20px 0;
+}
+
+#blog-posts h4 {
+  border-bottom: 1px solid #f0f0f0;
+}

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -1,0 +1,58 @@
+<div class="report-widget" id="blog-posts">
+  <h3><?= e(trans($this->property('title'))) ?></h3>
+
+  <h4><?= e(trans('winter.blog::lang.widgets.posts.latest')) ?></h4>
+  <p>
+    <strong><a href="<?= Backend::url('winter/blog/posts/update/' . $latest->id) ?>"><?= $latest->title ?></a></strong> (<?= Backend::dateTime($latest->published_at, ['formatAlias' => 'dateTimeMin']) ?>)
+  </p>
+
+  <p>
+    <strong><?= e(trans('winter.blog::lang.post.summary')) ?></strong>:
+    <?= $latest->summary ?>
+  </p>
+
+  <h4><?= e(trans('winter.blog::lang.widgets.posts.upcoming')) ?></h4>
+  <?php if(count($upcoming) == 0): ?>
+    <p><?= e(trans('winter.blog::lang.widgets.posts.no_upcoming_message')) ?></p>
+    <?php else: ?>
+      <div class="control-status-list">
+        <ul>
+          <?php foreach($upcoming as $post): ?>
+            <li>
+              <span class="status-icon success"><i class="icon-clock"></i></span>
+    
+              <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text success">
+                <?= $post->title ?>
+              </a>
+    
+              <span class="status-label link">
+                <?= Backend::dateTime($post->published_at, ['formatAlias' => 'dateTimeMin']) ?>
+              </span>
+            </li>
+          <?php endforeach ?>
+        </ul>
+      </div>
+  <?php endif ?>
+
+  <h4><?= e(trans('winter.blog::lang.widgets.posts.drafts')) ?></h4>
+  <?php if(count($drafts) == 0): ?>
+    <p><?= e(trans('winter.blog::lang.widgets.posts.no_drafts_message')) ?></p>
+  <?php else: ?>
+    <div class="control-status-list">
+      <ul>
+        <?php foreach($drafts as $post): ?>
+          <li>
+            <span class="status-icon muted"><i class="icon-info"></i></span>
+            <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text muted">
+              <?= $post->title ?>
+            </a>
+  
+            <a href="<?= Backend::url('backend/users/update/' . $post->user->id) ?>" class="status-label link">
+              <?= $post->user->full_name ?>
+            </a>
+          </li>
+        <?php endforeach ?>
+      </ul>
+    </div>
+  <?php endif ?>
+</div>

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -44,7 +44,7 @@
           <li>
             <span class="status-icon muted"><i class="icon-info"></i></span>
             <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text muted">
-              <?= $post->title ?>
+              <?= e($post->title) ?>
             </a>
   
           <?php if ($post->user): ?>

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -49,7 +49,7 @@
   
           <?php if ($post->user): ?>
             <a href="<?= Backend::url('backend/users/preview/' . $post->user->id) ?>" class="status-label link">
-              <?= $post->user->full_name ?>
+              <?= e($post->user->full_name) ?>
             </a>
           <?php endif; ?>
           </li>

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -1,60 +1,60 @@
 <div class="report-widget" id="blog-posts">
-  <h3><?= e(trans($this->property('title'))) ?></h3>
+    <h3><?= e(trans($this->property('title'))) ?></h3>
 
-  <h4><?= e(trans('winter.blog::lang.widgets.posts.latest')) ?></h4>
-  <p>
-    <strong><a href="<?= Backend::url('winter/blog/posts/update/' . $latest->id) ?>"><?= $latest->title ?></a></strong> (<?= Backend::dateTime($latest->published_at, ['formatAlias' => 'dateTimeMin']) ?>)
-  </p>
+    <h4><?= e(trans('winter.blog::lang.widgets.posts.latest')) ?></h4>
+    <p>
+        <strong><a href="<?= Backend::url('winter/blog/posts/update/' . $latest->id) ?>"><?= $latest->title ?></a></strong> (<?= Backend::dateTime($latest->published_at, ['formatAlias' => 'dateTimeMin']) ?>)
+    </p>
 
-  <p>
-    <strong><?= e(trans('winter.blog::lang.post.summary')) ?></strong>:
-    <?= $latest->summary ?>
-  </p>
+    <p>
+        <strong><?= e(trans('winter.blog::lang.post.summary')) ?></strong>:
+        <?= $latest->summary ?>
+    </p>
 
-  <h4><?= e(trans('winter.blog::lang.widgets.posts.upcoming')) ?></h4>
-  <?php if (count($upcoming) == 0): ?>
-    <p><?= e(trans('winter.blog::lang.widgets.posts.no_upcoming_message')) ?></p>
+    <h4><?= e(trans('winter.blog::lang.widgets.posts.upcoming')) ?></h4>
+    <?php if (count($upcoming) == 0): ?>
+        <p><?= e(trans('winter.blog::lang.widgets.posts.no_upcoming_message')) ?></p>
     <?php else: ?>
-      <div class="control-status-list">
-        <ul>
-          <?php foreach ($upcoming as $post): ?>
-            <li>
-              <span class="status-icon success"><i class="icon-clock"></i></span>
-    
-              <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text success">
-                <?= e($post->title) ?>
-              </a>
-    
-              <span class="status-label link">
-                <?= Backend::dateTime($post->published_at, ['formatAlias' => 'dateTimeMin']) ?>
-              </span>
-            </li>
-          <?php endforeach ?>
-        </ul>
-      </div>
-  <?php endif ?>
+        <div class="control-status-list">
+            <ul>
+                <?php foreach ($upcoming as $post): ?>
+                    <li>
+                        <span class="status-icon success"><i class="icon-clock"></i></span>
 
-  <h4><?= e(trans('winter.blog::lang.widgets.posts.drafts')) ?></h4>
-  <?php if (!count($drafts)): ?>
-    <p><?= e(trans('winter.blog::lang.widgets.posts.no_drafts_message')) ?></p>
-  <?php else: ?>
-    <div class="control-status-list">
-      <ul>
-        <?php foreach ($drafts as $post): ?>
-          <li>
-            <span class="status-icon muted"><i class="icon-info"></i></span>
-            <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text muted">
-              <?= e($post->title) ?>
-            </a>
-  
-          <?php if ($post->user): ?>
-            <a href="<?= Backend::url('backend/users/preview/' . $post->user->id) ?>" class="status-label link">
-              <?= e($post->user->full_name) ?>
-            </a>
-          <?php endif; ?>
-          </li>
-        <?php endforeach ?>
-      </ul>
-    </div>
-  <?php endif ?>
+                        <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text success">
+                            <?= e($post->title) ?>
+                        </a>
+
+                        <span class="status-label link">
+                            <?= Backend::dateTime($post->published_at, ['formatAlias' => 'dateTimeMin']) ?>
+                        </span>
+                    </li>
+                <?php endforeach ?>
+            </ul>
+        </div>
+    <?php endif ?>
+
+    <h4><?= e(trans('winter.blog::lang.widgets.posts.drafts')) ?></h4>
+    <?php if (!count($drafts)): ?>
+        <p><?= e(trans('winter.blog::lang.widgets.posts.no_drafts_message')) ?></p>
+    <?php else: ?>
+        <div class="control-status-list">
+            <ul>
+                <?php foreach ($drafts as $post): ?>
+                    <li>
+                        <span class="status-icon muted"><i class="icon-info"></i></span>
+                        <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text muted">
+                            <?= e($post->title) ?>
+                        </a>
+
+                        <?php if ($post->user): ?>
+                            <a href="<?= Backend::url('backend/users/preview/' . $post->user->id) ?>" class="status-label link">
+                                <?= e($post->user->full_name) ?>
+                            </a>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach ?>
+            </ul>
+        </div>
+    <?php endif ?>
 </div>

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -2,14 +2,18 @@
     <h3><?= e(trans($this->property('title'))) ?></h3>
 
     <h4><?= e(trans('winter.blog::lang.widgets.posts.latest')) ?></h4>
+    <?php if (!$latest): ?>
+        <p><?= e(trans('winter.blog::lang.widgets.posts.no_latest_message')) ?></p>
+    <?php else: ?>
     <p>
-        <strong><a href="<?= Backend::url('winter/blog/posts/update/' . $latest->id) ?>"><?= $latest->title ?></a></strong> (<?= Backend::dateTime($latest->published_at, ['formatAlias' => 'dateTimeMin']) ?>)
+        <strong><a href="<?= Backend::url('winter/blog/posts/update/' . $latest->id) ?>"><?= e($latest->title) ?></a></strong> (<?= Backend::dateTime($latest->published_at, ['formatAlias' => 'dateTimeMin']) ?>)
     </p>
 
     <p>
         <strong><?= e(trans('winter.blog::lang.post.summary')) ?></strong>:
-        <?= $latest->summary ?>
+        <?= e($latest->summary) ?>
     </p>
+    <?php endif ?>
 
     <h4><?= e(trans('winter.blog::lang.widgets.posts.upcoming')) ?></h4>
     <?php if (count($upcoming) == 0): ?>

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -47,9 +47,11 @@
               <?= $post->title ?>
             </a>
   
+          <?php if ($post->user): ?>
             <a href="<?= Backend::url('backend/users/update/' . $post->user->id) ?>" class="status-label link">
               <?= $post->user->full_name ?>
             </a>
+          <?php endif; ?>
           </li>
         <?php endforeach ?>
       </ul>

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -40,7 +40,7 @@
   <?php else: ?>
     <div class="control-status-list">
       <ul>
-        <?php foreach($drafts as $post): ?>
+        <?php foreach ($drafts as $post): ?>
           <li>
             <span class="status-icon muted"><i class="icon-info"></i></span>
             <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text muted">

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -17,7 +17,7 @@
     <?php else: ?>
       <div class="control-status-list">
         <ul>
-          <?php foreach($upcoming as $post): ?>
+          <?php foreach ($upcoming as $post): ?>
             <li>
               <span class="status-icon success"><i class="icon-clock"></i></span>
     

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -12,7 +12,7 @@
   </p>
 
   <h4><?= e(trans('winter.blog::lang.widgets.posts.upcoming')) ?></h4>
-  <?php if(count($upcoming) == 0): ?>
+  <?php if (count($upcoming) == 0): ?>
     <p><?= e(trans('winter.blog::lang.widgets.posts.no_upcoming_message')) ?></p>
     <?php else: ?>
       <div class="control-status-list">

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -35,7 +35,7 @@
   <?php endif ?>
 
   <h4><?= e(trans('winter.blog::lang.widgets.posts.drafts')) ?></h4>
-  <?php if(count($drafts) == 0): ?>
+  <?php if (!count($drafts)): ?>
     <p><?= e(trans('winter.blog::lang.widgets.posts.no_drafts_message')) ?></p>
   <?php else: ?>
     <div class="control-status-list">

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -48,7 +48,7 @@
             </a>
   
           <?php if ($post->user): ?>
-            <a href="<?= Backend::url('backend/users/update/' . $post->user->id) ?>" class="status-label link">
+            <a href="<?= Backend::url('backend/users/preview/' . $post->user->id) ?>" class="status-label link">
               <?= $post->user->full_name ?>
             </a>
           <?php endif; ?>

--- a/reportwidgets/posts/partials/_widget.php
+++ b/reportwidgets/posts/partials/_widget.php
@@ -22,7 +22,7 @@
               <span class="status-icon success"><i class="icon-clock"></i></span>
     
               <a href="<?= Backend::url('winter/blog/posts/update/' . $post->id) ?>" class="status-text success">
-                <?= $post->title ?>
+                <?= e($post->title) ?>
               </a>
     
               <span class="status-label link">


### PR DESCRIPTION
Following up on my recent new admin dashboard widget plugin, I figured it would also be nice to have a blog post widget. That would be nice for personal websites with an attached blog (such as my own website) to provide an overview over the posts at a glance.

Collocating this one with the blog plugin keeps the logic slimmer than if I were to add it to the other plugin, that's why I'm opening a PR for this.

I took a few decisions based on my own experience, but I believe it should work for most cases.

## Widget

<img width="542" height="324" alt="image" src="https://github.com/user-attachments/assets/cbce7141-fec9-4324-bfc5-6726793d4cc2" />

The widget is relatively simple: It has three sections. The first one shows the most recent published blog post, the second one shows the next up to five scheduled posts so that one can get an overview over what will be coming, and the last section shows up to five drafts that have not yet been scheduled.

## Changes

* Add a blog post overview widget
  * Each blog post links to the update page for quick access to the draft/scheduled/published post
  * The scheduled posts come with the `published_at` date to quickly spot potential holes in the publishing pipeline
  * The "latest" post comes with title, publishing date, and the summary
* Added English + German translation

Let me know what you think!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard widget showing the latest published post (with summary), up to five drafts, and up to five upcoming scheduled posts — includes quick-edit links and author info for easy management.

* **Translations**
  * Added localized UI strings for the widget in English and German.

* **Style**
  * Minor CSS tweaks to spacing and borders for the widget layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->