### PR TITLE
feat: Make Feed Atom 1.0 valid

### DIFF
--- a/components/RssFeed.php
+++ b/components/RssFeed.php
@@ -108,7 +108,7 @@ class RssFeed extends ComponentBase
 
         $xmlFeed = $this->renderPartial('@default');
 
-        return Response::make($xmlFeed, '200')->header('Content-Type', 'text/xml');
+        return Response::make($xmlFeed, '200')->header('Content-Type', 'application/atom+xml');
     }
 
     protected function prepareVars(): void

--- a/components/rssfeed/default.htm
+++ b/components/rssfeed/default.htm
@@ -1,22 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-    <channel>
-        <title>{{ this.page.meta_title ?: this.page.title }}</title>
-        <link>{{ link }}</link>
-        <description>{{ this.page.meta_description ?: this.page.description }}</description>
-        <atom:link rel="self" href="{{ rssLink }}" type="application/rss+xml" />
-        <link rel="first" href="{{ paginationLinks.first }}"/>
-        {% if paginationLinks.prev %}<link rel="previous" href="{{ paginationLinks.prev }}"/>{% endif %}
-        {% if paginationLinks.next %}<link rel="next" href="{{ paginationLinks.next }}"/>{% endif %}
-        <link rel="last" href="{{ paginationLinks.last }}"/>
-        {% for post in posts %}
-        <item>
-            <title>{{ post.title }}</title>
-            <link>{{ post.url }}</link>
-            <guid>{{ post.url }}</guid>
-            <pubDate>{{ post.published_at.toRfc2822String }}</pubDate>
-            <description>{{ post.summary }}</description>
-        </item>
-        {% endfor %}
-    </channel>
-</rss>
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>{{ this.page.meta_title ?: this.page.title }}</title>
+<generator>WinterCMS Winter Blog Plugin</generator>
+
+<link rel="alternate" type="text/html" href="{{ link }}" />
+<link rel="self" type="application/atom+xml" href="{{ rssLink }}" />
+<id>{{ link }}</id>
+
+<updated>{{ "now"|date("c") }}</updated>
+
+{% for post in posts %}
+<entry>
+  <title>{{ post.title }}</title>
+  <author>
+    <name>{{ post.user.full_name }}</name>
+  </author>
+  <rights>Copyright © {{ post.published_at|date("Y") }}, {{ post.user.full_name }}</rights>
+  <link rel="alternate" href="{{ post.url }}" />
+  <id>{{ post.url }}</id>
+  <published>{{ post.published_at|date("c") }}</published>
+  <updated>{{ post.updated_at|date("c") }}</updated>
+  <summary type="html"><![CDATA[{{ post.summary }}]]></summary>
+  <content type="html" xml:base="{{ post.url }}">
+    <![CDATA[{{ post.content_html | raw }}]]>
+  </content>
+</entry>
+{% endfor %}
+</feed>

--- a/components/rssfeed/default.htm
+++ b/components/rssfeed/default.htm
@@ -28,9 +28,9 @@
   <id>{{ post.url }}</id>
   <published>{{ post.published_at|date("c") }}</published>
   <updated>{{ post.updated_at|date("c") }}</updated>
-  <summary type="html"><![CDATA[{{ post.summary }}]]></summary>
+  <summary type="html"><![CDATA[{{ post.summary | replace("]]>", "]]&gt;") }}]]></summary>
   <content type="html" xml:base="{{ post.url }}">
-    <![CDATA[{{ post.content_html | raw }}]]>
+    <![CDATA[{{ post.content_html | raw | replace("]]>", "]]&gt;") }}]]>
   </content>
 </entry>
 {% endfor %}

--- a/components/rssfeed/default.htm
+++ b/components/rssfeed/default.htm
@@ -12,10 +12,18 @@
 {% for post in posts %}
 <entry>
   <title>{{ post.title }}</title>
+  {% if post.user %}
   <author>
     <name>{{ post.user.full_name }}</name>
   </author>
   <rights>Copyright © {{ post.published_at|date("Y") }}, {{ post.user.full_name }}</rights>
+  {% else %}
+  <author>
+    <name>{{ this.page.meta_title ?: this.page.title }}</name>
+  </author>
+  <rights>Copyright © {{ post.published_at|date("Y") }}, {{ this.page.meta_title ?: this.page.title }}</rights>
+  {% endif %}
+
   <link rel="alternate" href="{{ post.url }}" />
   <id>{{ post.url }}</id>
   <published>{{ post.published_at|date("c") }}</published>

--- a/components/rssfeed/default.htm
+++ b/components/rssfeed/default.htm
@@ -30,10 +30,10 @@
         {% endif %}
 
         <summary type="html">
-            <![CDATA[{{ post.summary | replace("]]>", "]]&gt;") }}]]>
+            <![CDATA[{{ post.summary | replace("]]>": "]]&gt;") }}]]>
         </summary>
         <content type="html" xml:base="{{ post.url }}">
-            <![CDATA[{{ post.content_html | raw | replace("]]>", "]]&gt;") }}]]>
+            <![CDATA[{{ post.content_html | raw | replace("]]>": "]]&gt;") }}]]>
         </content>
     </entry>
     {% endfor %}

--- a/components/rssfeed/default.htm
+++ b/components/rssfeed/default.htm
@@ -1,37 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-<title>{{ this.page.meta_title ?: this.page.title }}</title>
-<generator>WinterCMS Winter Blog Plugin</generator>
+    <title>{{ this.page.meta_title ?: this.page.title }}</title>
+    <generator>WinterCMS Winter Blog Plugin</generator>
 
-<link rel="alternate" type="text/html" href="{{ link }}" />
-<link rel="self" type="application/atom+xml" href="{{ rssLink }}" />
-<id>{{ link }}</id>
+    <link rel="alternate" type="text/html" href="{{ link }}" />
+    <link rel="self" type="application/atom+xml" href="{{ rssLink }}" />
+    <id>{{ link }}</id>
 
-<updated>{{ "now"|date("c") }}</updated>
+    <updated>{{ "now"|date("c") }}</updated>
 
-{% for post in posts %}
-<entry>
-  <title>{{ post.title }}</title>
-  {% if post.user %}
-  <author>
-    <name>{{ post.user.full_name }}</name>
-  </author>
-  <rights>Copyright © {{ post.published_at|date("Y") }}, {{ post.user.full_name }}</rights>
-  {% else %}
-  <author>
-    <name>{{ this.page.meta_title ?: this.page.title }}</name>
-  </author>
-  <rights>Copyright © {{ post.published_at|date("Y") }}, {{ this.page.meta_title ?: this.page.title }}</rights>
-  {% endif %}
+    {% for post in posts %}
+    <entry>
+        <title>{{ post.title }}</title>
+        <link rel="alternate" href="{{ post.url }}" />
+        <id>{{ post.url }}</id>
+        <published>{{ post.published_at|date("c") }}</published>
+        <updated>{{ post.updated_at|date("c") }}</updated>
 
-  <link rel="alternate" href="{{ post.url }}" />
-  <id>{{ post.url }}</id>
-  <published>{{ post.published_at|date("c") }}</published>
-  <updated>{{ post.updated_at|date("c") }}</updated>
-  <summary type="html"><![CDATA[{{ post.summary | replace("]]>", "]]&gt;") }}]]></summary>
-  <content type="html" xml:base="{{ post.url }}">
-    <![CDATA[{{ post.content_html | raw | replace("]]>", "]]&gt;") }}]]>
-  </content>
-</entry>
-{% endfor %}
+        {% if post.user %}
+        <author>
+            <name>{{ post.user.full_name }}</name>
+        </author>
+        <rights>Copyright © {{ post.published_at|date("Y") }}, {{ post.user.full_name }}</rights>
+        {% else %}
+        <author>
+            <name>{{ this.page.meta_title ?: this.page.title }}</name>
+        </author>
+        <rights>Copyright © {{ post.published_at|date("Y") }}, {{ this.page.meta_title ?: this.page.title }}</rights>
+        {% endif %}
+
+        <summary type="html">
+            <![CDATA[{{ post.summary | replace("]]>", "]]&gt;") }}]]>
+        </summary>
+        <content type="html" xml:base="{{ post.url }}">
+            <![CDATA[{{ post.content_html | raw | replace("]]>", "]]&gt;") }}]]>
+        </content>
+    </entry>
+    {% endfor %}
 </feed>

--- a/components/rssfeed/default.htm
+++ b/components/rssfeed/default.htm
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ this.page.meta_title ?: this.page.title }}</title>
-    <generator>WinterCMS Winter Blog Plugin</generator>
+    <generator>WinterCMS.Blog Plugin</generator>
 
     <link rel="alternate" type="text/html" href="{{ link }}" />
     <link rel="self" type="application/atom+xml" href="{{ rssLink }}" />


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->

That was easier than expected -- this PR makes the Winter Blog generated feed Atom 1.0 valid. It does so by simply adjusting and modifying the feed template according to [RFC 4287](https://datatracker.ietf.org/doc/html/rfc4287).

## Changes

* The template now updates the syntax to the correct Atom 1.0 specification
* The template now emits the actual post content HTML into the feed
* Wrap summary and content into `<![CDATA[]]>` to ensure proper parsing by feed readers
* Move dates from RFC 2822 to ISO 8601 in accordance with RFC 4287
* Adds a few additional fields: `generator` to identify the plugin as the generator; `rights` to indicate copyright
* Emit the correct mime type header from the component file (`application/atom+xml` instead of `text/xml`)

## Additional Information

This PR is only the first of potentially more to improve feed experience. Additional fields that could be made configurable are: `icon` (for a preview icon), `logo` (for a bigger logo type), `subtitle` (for a description/subtitle of the feed), `category`s to denote an article's categories, and make various existing fields configurable.

But since we can now at least ship valid Atom 1.0 feeds, I thought this is a minimal-effort improvement to the plugin itself, and users can still override the partial how they like (which is how I am currently inserting logos, icons, and subtitles).

Let me know if that looks for now good to you, or if I should do some changes to this particular improvement already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Feeds**
  * Feed output switched to Atom (Content-Type: application/atom+xml).
  * Atom feed includes richer metadata: author blocks, ISO-formatted published/updated timestamps, per-entry links/IDs, and explicit rights/copyright.
  * Entries now emit HTML summary and full content in Atom elements for improved feed reader rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->